### PR TITLE
Added makefile targets to hardwar rngs to make testing and experimenting easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,9 @@ apps/sim.logpwd
 .vscode/
 .DS_Store
 rngs/hardware/*.vcd
-rngs/hardware/sim.log
-rngs/hardware/synth.log
-rngs/hardware/gatesim.log
+rngs/hardware/*-sim.log
+rngs/hardware/*-synth.log
+rngs/hardware/*-gatesim.log
 rngs/hardware/*-sim
 rngs/hardware/*-gatesim
 rngs/hardware/*.netlist.v

--- a/rngs/hardware/Makefile
+++ b/rngs/hardware/Makefile
@@ -1,11 +1,31 @@
 include $(STOCHSUITE_HOME)/stochsuite.mk
 
+DUT ?= taus88
+XILINX_CELLS_DIR ?= XilinxUnisimLibrary/verilog/src
+IVERILOG ?= /usr/bin/iverilog
+YOSYS ?= /usr/bin/yosys
+
+sim: ${DUT}-sim
+	./$< +VCDFILE=sim.vcd +VCDLEVEL=0 | tee ${DUT}-sim.log
+
+${DUT}-sim: ${DUT}_tb.v ${DUT}.v
+	${IVERILOG} -g2005-sv -s ${DUT}_tb -y ${XILINX_CELLS_DIR} -o $@ $^
+
+synth: ${DUT}.netlist.v
+
+${DUT}.netlist.v: ${DUT}.v
+	${YOSYS} -p 'synth_xilinx -top ${DUT}' -p stat $< -L ${DUT}-synth.log -o $@
+
+gatesim: ./${DUT}-gatesim
+	./$< +VCDFILE=gatesim.vcd +VCDLEVEL=1 | tee ${DUT}-gatesim.log
+
+${DUT}-gatesim: ${DUT}_tb.v ${DUT}.netlist.v
+	${IVERILOG} -g2005-sv -s ${DUT}_tb -DGATESIM -y ${XILINX_CELLS_DIR} -y ${XILINX_CELLS_DIR}/unisims -o $@ $^
+
 clean:
-	@rm -f TB-sim
-	@rm -f JKISS-sim
-	@rm -f Taus88-gatesim
-	@rm -f sim.log
-	@rm -f synth.log
-	@rm -f gatesim.log
-	@rm -f taus88.netlist.v
-	@rm -f taus88_opt.netlist.v
+	@rm -f *-sim
+	@rm -f *-gatesim
+	@rm -f *-sim.log
+	@rm -f *-synth.log
+	@rm -f *-gatesim.log
+	@rm -f *.netlist.v

--- a/rngs/hardware/README.md
+++ b/rngs/hardware/README.md
@@ -4,8 +4,12 @@
 
 The testbench can be compiled and run with the following command
 ```
-iverilog taus88.v taus88_tb.v -s Taus88_TB -y XilinxUnisimLibrary/verilog/src -o TB-sim && ./TB-sim +VCDFILE=sim.vcd +VCDLEVEL=0 | tee sim.log
+make sim DUT=taus88 
 ```
+
+Note, the argument to the `DUT` parameter must match the name of the
+source verilog file, the prefix of the testbench file name, as well 
+as the prefix for the testbench module name.
 
 The hardware testbench checks against values produced from the software implementation, i.e. output from: 
 
@@ -48,7 +52,7 @@ cd $STOCHSUITE_HOME/rngs/hardware/
 The following command will attempt to use Xilinx primitives to create a netlist to implement design
 
 ```
-yosys -p 'synth_xilinx -top taus88' -p stat taus88.v -o taus88.netlist.v | tee  synth.log
+make synth DUT=taus88
 ```
 
 You should see output like:
@@ -84,8 +88,7 @@ the design functionally completes from it's netlist implementation. The followin
 commands rerun the simulation using the netlist output as the DUT:
 
 ```
-iverilog -g2005-sv -s Taus88_TB -DGATESIM -y XilinxUnisimLibrary/verilog/src -y XilinxUnisimLibrary/verilog/src/unisims taus88.netlist.v taus88_tb.v -o Taus88-gatesim
-./Taus88-gatesim +VCDFILE=gatesim.vcd +VCDLEVEL=1 | tee gatesim.log
+make gatesim DUT=taus88
 ```
 
 
@@ -94,13 +97,13 @@ iverilog -g2005-sv -s Taus88_TB -DGATESIM -y XilinxUnisimLibrary/verilog/src -y 
 TODO seems like this implementation is broken
 
 ```
-iverilog taus88_opt.v taus88_opt_tb.v -s Taus88_Optimized_TB -y XilinxUnisimLibrary/verilog/src -o TB-sim && ./TB-sim +VCDFILE=sim.vcd +VCDLEVEL=0 | tee sim.log
-yosys -p 'synth_xilinx -top taus88_opt' -p stat taus88_opt.v -o taus88_opt.netlist.v | tee  synth.log
+make sim DUT=taus88_opt
+make synth DUT=taus88_opt
 ```
 
 ## Testing JKISS
 
 ```
 ./util/correctness.o -iters 10 -seed 0xdeadbeef -rng JKISS
-iverilog jkiss.v jkiss_tb.v -s JKISS_TB -y XilinxUnisimLibrary/verilog/src -o JKISS-sim && ./JKISS-sim +VCDFILE=sim.vcd +VCDLEVEL=0 | tee sim.log
+make sim DUT=jkiss
 ```

--- a/rngs/hardware/jkiss_tb.v
+++ b/rngs/hardware/jkiss_tb.v
@@ -3,10 +3,11 @@
 
 `timescale 1ns/1ps
 
-module JKISS_TB;
+module jkiss_tb;
 
-    // only for gatesim
+`ifdef GATESIM
     glbl glbl ();
+`endif
     reg         clk;
     reg         rst_n;
     reg  [31:0] seed;

--- a/rngs/hardware/taus88_opt_tb.v
+++ b/rngs/hardware/taus88_opt_tb.v
@@ -3,10 +3,11 @@
 
 `timescale 1ns/1ps
 
-module Taus88_Optimized_TB;
+module taus88_opt_tb;
 
-    // only for gatesim
+`ifdef GATESIM
     glbl glbl ();
+`endif
     reg         clk;
     reg         rst_n;
     reg  [31:0] seed;

--- a/rngs/hardware/taus88_tb.v
+++ b/rngs/hardware/taus88_tb.v
@@ -3,7 +3,7 @@
 
 `timescale 1ns/1ps
 
-module Taus88_TB;
+module taus88_tb;
 
     glbl glbl ();
     reg         clk;


### PR DESCRIPTION
This PR adds targets to the `Makefile` in `rngs/hardware/`. The targets will allow users to simulate, synthesize, and simulate with gate level representations of their hardware implementations of PRNGs with ease. The README in `rngs/hardware/` is updated as well to show how to use the targets.