### PR TITLE
Removal of Duplicate Code in Xorwow Verilog Impl

### DIFF
--- a/rngs/hardware/xorwow.v
+++ b/rngs/hardware/xorwow.v
@@ -62,10 +62,6 @@ module xorwow (
     // ---- output  ----
     assign rnd = d_cur + v_cur;
 
-
-    // ---- output  ----
-    assign rnd = d_cur + v_cur;
-
 endmodule
 
 `endif // __XORWOW_V__


### PR DESCRIPTION
Duplicate continuous assign statements may cause an issue with multiple drivers to the same wire. Removing duplicate code.