### PR TITLE
Exposing State Bytes from Software PRNGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ rngs/software/*.o
 apps/*.o
 apps/util/*.o
 apps/*.ppm
+apps/*.bin
+apps/*.hex
 apps/*_results.txt
 apps/*_results.csv
 apps/sim.logcd
@@ -16,3 +18,5 @@ rngs/hardware/*-sim
 rngs/hardware/*-gatesim
 rngs/hardware/*.netlist.v
 rngs/hardware/*.lib
+rngs/hardware/*.bin
+rngs/hardware/*.hex

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -25,6 +25,5 @@ all:
 	    $(CPP) -I$(RNG_LIB) $(RNG_OBJS) $(LFLAGS) $(PLATFORM_CFLAGS) util/latency.cpp -o util/latency.o; \
 	fi
 clean:
-	@rm -f *.o
+	@rm -f *.o *.ppm *.bin *.hex
 	@rm -f util/*.o
-	@rm -f *.ppm

--- a/apps/util/correctness.cpp
+++ b/apps/util/correctness.cpp
@@ -12,13 +12,15 @@ int main(int argc, char *argv[]) {
     size_t niters = 10;
     uint32_t seed = 1634404289;
     std::string rngStr = "Taus88";
+    bool dumpState = false;
+    std::string dumpStateFilename = "Taus88_initial_state.hex";
     int saved_errno;
     char* endptr;
 
     if (argc > 1) {
         if (argc > 7) {
             std::cout << "usage: ./" << argv[0] << " -seed <SEED> ";
-            std::cout << " -iters <NUM_ITERS> -rng <RNG>" << std::endl;
+            std::cout << " -iters <NUM_ITERS> -rng <RNG> -dump_state <FILENAME>" << std::endl;
             return 1;
         }
         for (size_t i = 0; i < (size_t)argc; i++) {
@@ -51,6 +53,12 @@ int main(int argc, char *argv[]) {
                 rngStr = (std::string) argv[i+1];
                 i++;
             }
+            if (strcmp("-dump_state", argv[i]) == 0) {
+                assert(i + 1 < (size_t)argc);
+                dumpStateFilename = (std::string) argv[i+1];
+                dumpState = true;
+                i++;
+            }
         }
     }
     std::unique_ptr<RNGBase> rng = RNGFactory::createRNG(rngStr);
@@ -61,6 +69,11 @@ int main(int argc, char *argv[]) {
     std::cout << "Successfully initialized RNG: " << rng->name() << std::endl;
 
     rng->seed_random(seed);
+
+    if (dumpState) {
+        rng->dump_state(dumpStateFilename);
+    }
+    
     uint32_t rnd;
     for (size_t i = 0; i < niters; i++) {
         rnd = rng->read_random();

--- a/rngs/software/RNGState.cpp
+++ b/rngs/software/RNGState.cpp
@@ -1,6 +1,8 @@
 #include "RNGState.hpp"
 
 #include <cassert>
+#include <cstdio>
+
 
 RNGState::RNGState(size_t numBytes)
     : numBytes(numBytes) {
@@ -63,7 +65,18 @@ uint8_t RNGState::get_state_byte(size_t state_offset) {
 
 size_t RNGState::size() { 
     return numBytes; 
-} 
+}
+
+void RNGState::dump(std::string filename) { 
+
+    // Write the hex values of the state bytes to a file, one byte per line and also print them to the console
+    FILE *f = fopen(filename.c_str(), "w");
+    for (size_t i = 0; i < numBytes; i++) {
+        fprintf(f, "%02x\n", allState[i]);
+        printf("State byte %zu: %u %02x\n", i, (uint32_t) allState[i], allState[i]);
+    }
+    fclose(f);
+}
 
 RNGState::~RNGState() {
     delete[] allState;

--- a/rngs/software/RNGState.hpp
+++ b/rngs/software/RNGState.hpp
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <cstddef>
+#include <string>
 
 class RNGState {
     public:
@@ -19,6 +20,7 @@ class RNGState {
         uint8_t get_state_byte(size_t state_offset);
         uint8_t *getState();
         size_t size();
+        void dump(std::string filename);
     protected:
         uint8_t *allState;
         size_t numBytes;

--- a/rngs/software/RandomNumberGenerator.cpp
+++ b/rngs/software/RandomNumberGenerator.cpp
@@ -80,6 +80,10 @@ void RNGBase::seed_random(uint32_t new_seed) {
     _seed_random(new_seed);
 }
 
+void RNGBase::dump_state(std::string filename) {
+    state->dump(filename);
+}
+
 RNGBase::~RNGBase() {
     delete state;
 }

--- a/rngs/software/RandomNumberGenerator.hpp
+++ b/rngs/software/RandomNumberGenerator.hpp
@@ -34,6 +34,8 @@ class RNGBase {
         double gaussian_box_muller();
         double gaussian_box_muller(double mean, double stddev);
         double lognormal_distribution(double mean, double stddev);
+
+        void dump_state(std::string filename);
         
     protected:
         RNGState* state;


### PR DESCRIPTION
For accurate replay and correctness checking, it's useful to have the entire state of a software PRNG visible. This PR adds support to dump the internal state of a software PRNG into a hex file, that can readily be used by a verilog testbench. This is especially useful for PRNGs with large memory footprints, like the MersenneTwister generator. An example of how to use the new `dump_state` API is shown in the `correctness.cpp` application. 