### PR TITLE
Initial Support for gem5 Sycall Emulation Mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/Xilinx/XilinxUnisimLibrary
 [submodule "gem5_sim/gem5"]
 	path = gem5_sim/gem5
-	url = https://github.com/BujSet/gem5.git
-	branch = stochsuite
+    url = https://github.com/pi-dee/stochsuite_gem5.git
+	branch =more_details


### PR DESCRIPTION
Changes the the submodule endpoint to a gem5 fork that successfully runs and simulates the applications using the PRNG library from this repo.