### PR TITLE
Implementation of the 1988 Park and Miller PRNG 

### DIFF
--- a/rngs/software/Makefile
+++ b/rngs/software/Makefile
@@ -23,6 +23,7 @@ all:
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) LCG.cpp -o LCG.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) MersenneTwister.cpp -o MersenneTwister.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) KISS11.cpp -o KISS11.o
+	@$(CPP) -I$(RNG_LIB) $(CFLAGS) Park1988.cpp -o Park1988.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) PCGBasic.cpp -o PCGBasic.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) HWRNG.cpp -o HWRNG.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) XorShift32.cpp -o XorShift32.o

--- a/rngs/software/Park1988.cpp
+++ b/rngs/software/Park1988.cpp
@@ -1,0 +1,34 @@
+#include "Park1988.hpp"
+
+Park1988::Park1988() : RNGBase(4) {
+    state->set_state_bytes_from_int(1979, 4, 0);
+}
+
+Park1988::Park1988(uint32_t seed): RNGBase(4) {
+    _name = name;
+    state->set_state_bytes_from_int(seed, 4, 0);
+}
+
+void Park1988::_seed_random(uint32_t new_seed) {
+    state->set_state_bytes_from_int(new_seed, 4, 0);
+}
+
+
+std::string Park1988::name() {
+    return "Park1988";
+}
+
+uint32_t LCG::_read_random(){
+    uint32_t s = state->get_state_bytes_as_int(0);
+    uint32_t hi, lo;
+    int32_t test;
+    hi = s / Park1988::q;
+    lo = s % Park1988::q;
+    test = (Park1988::a * lo) - (Park1988::r * hi);
+    s = test;
+    if (test <= 0) {
+        s += Park1988::m;
+    }
+    state->set_state_bytes_from_int(s, 4, 0);
+    return s / Park1988::m;
+}

--- a/rngs/software/Park1988.cpp
+++ b/rngs/software/Park1988.cpp
@@ -5,7 +5,6 @@ Park1988::Park1988() : RNGBase(4) {
 }
 
 Park1988::Park1988(uint32_t seed): RNGBase(4) {
-    _name = name;
     state->set_state_bytes_from_int(seed, 4, 0);
 }
 
@@ -13,12 +12,17 @@ void Park1988::_seed_random(uint32_t new_seed) {
     state->set_state_bytes_from_int(new_seed, 4, 0);
 }
 
-
 std::string Park1988::name() {
     return "Park1988";
 }
 
-uint32_t LCG::_read_random(){
+double Park1988::read_random_double(){
+    uint32_t int_out = _read_random();
+    double result = 1.0 * int_out / Park1988::m;
+    return result;
+}
+
+uint32_t Park1988::_read_random(){
     uint32_t s = state->get_state_bytes_as_int(0);
     uint32_t hi, lo;
     int32_t test;
@@ -30,5 +34,5 @@ uint32_t LCG::_read_random(){
         s += Park1988::m;
     }
     state->set_state_bytes_from_int(s, 4, 0);
-    return s / Park1988::m;
+    return s;
 }

--- a/rngs/software/Park1988.hpp
+++ b/rngs/software/Park1988.hpp
@@ -1,0 +1,24 @@
+#ifndef __PARK_AND_MILLER_1988_GENERATOR__
+#define __PARK_AND_MILLER_1988_GENERATOR__
+
+#include "RandomNumberGenerator.hpp"
+
+#include <stdint.h>
+#include <cstddef>
+
+class Park1988: public RNGBase {
+    public:
+        Park1988();
+        Park1988(uint32_t seed);
+        uint32_t _read_random() override;
+        void _seed_random(uint32_t new_seed) override;
+        std::string name() override;
+
+        static const uint32_t a = 16807;
+        static const uint32_t m = ;
+        static const uint32_t q = ;
+        static const uint32_t r = ;
+    private:
+        std::string _name;
+};
+#endif // __PARK_AND_MILLER_1988_GENERATOR__

--- a/rngs/software/Park1988.hpp
+++ b/rngs/software/Park1988.hpp
@@ -12,13 +12,12 @@ class Park1988: public RNGBase {
         Park1988(uint32_t seed);
         uint32_t _read_random() override;
         void _seed_random(uint32_t new_seed) override;
+        double read_random_double() override;
         std::string name() override;
 
         static const uint32_t a = 16807;
-        static const uint32_t m = ;
-        static const uint32_t q = ;
-        static const uint32_t r = ;
-    private:
-        std::string _name;
+        static const uint32_t m = 2147483647;
+        static const uint32_t q = 127773;
+        static const uint32_t r = 2836;
 };
 #endif // __PARK_AND_MILLER_1988_GENERATOR__

--- a/rngs/software/RNGFactory.cpp
+++ b/rngs/software/RNGFactory.cpp
@@ -6,6 +6,7 @@
 #include "KISS11.hpp"
 #include "LCG.hpp"
 #include "MersenneTwister.hpp"
+#include "Park1988.hpp"
 #include "PCGBasic.hpp"
 #include "Taus88.hpp"
 #include "Taus113.hpp"
@@ -76,6 +77,12 @@ std::unique_ptr<RNGBase> RNGFactory::createRNG(const std::string type) {
     } else if (type == "XoShiRo128++") {
         // Implemented from https://prng.di.unimi.it/xoshiro128plusplus.c
         return std::unique_ptr<RNGBase>(new XoShiRo128PlusPlus());
+    } else if (type == "ParkAndMiller1988Int2") {
+        // Implemented from S. K. Park and K. W. Miller. 1988. 
+        // Random number generators: good ones are hard to find. Commun. 
+        // ACM 31, 10 (Oct. 1988), 1192–1201. 
+        // https://doi.org/10.1145/63039.63042
+        return std::unique_ptr<RNGBase>(new Park1988());
     } else {
         return nullptr;
     }

--- a/rngs/software/RandomNumberGenerator.hpp
+++ b/rngs/software/RandomNumberGenerator.hpp
@@ -29,7 +29,7 @@ class RNGBase {
         virtual uint32_t MAX() { return 0xFFFFFFFF; };
         virtual uint32_t MIN() { return 0xFFFFFFFF; };
 
-        double read_random_double();
+        virtual double read_random_double();
 
         double gaussian_box_muller();
         double gaussian_box_muller(double mean, double stddev);


### PR DESCRIPTION
Software implementation of the integer pseudo-random number generator from the publication: S. K. Park and K. W. Miller. 1988. Random number generators: good ones are hard to find. Commun. ACM 31, 10 (Oct. 1988), 1192–1201. https://doi.org/10.1145/63039.63042. This change implements version 2 of the integer implementation, in the right column on page 1195.

This change also extends the base class to allow PRNG implementations to override the method to return random doubles.