### PR TITLE
Implementation of UpCounter PRNG

### DIFF
--- a/rngs/software/Makefile
+++ b/rngs/software/Makefile
@@ -18,6 +18,7 @@ all:
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) RNGFactory.cpp -o RNGFactory.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) Taus88.cpp -o Taus88.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) Taus113.cpp -o Taus113.o
+	@$(CPP) -I$(RNG_LIB) $(CFLAGS) UpCounter.cpp -o UpCounter.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) JKISS.cpp -o JKISS.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) JKISS32.cpp -o JKISS32.o
 	@$(CPP) -I$(RNG_LIB) $(CFLAGS) LCG.cpp -o LCG.o

--- a/rngs/software/RNGFactory.cpp
+++ b/rngs/software/RNGFactory.cpp
@@ -10,6 +10,7 @@
 #include "PCGBasic.hpp"
 #include "Taus88.hpp"
 #include "Taus113.hpp"
+#include "UpCounter.hpp"
 #include "XorShift128.hpp"
 #include "XorShift32.hpp"
 #include "XorWow.hpp"
@@ -83,6 +84,8 @@ std::unique_ptr<RNGBase> RNGFactory::createRNG(const std::string type) {
         // ACM 31, 10 (Oct. 1988), 1192–1201. 
         // https://doi.org/10.1145/63039.63042
         return std::unique_ptr<RNGBase>(new Park1988());
+    } else if (type == "UpCounter") {
+        return std::unique_ptr<RNGBase>(new UpCounter());
     } else {
         return nullptr;
     }

--- a/rngs/software/UpCounter.cpp
+++ b/rngs/software/UpCounter.cpp
@@ -1,0 +1,23 @@
+#include "UpCounter.hpp"
+
+UpCounter::UpCounter() : RNGBase(4) {
+    state->set_state_bytes_from_int(0, 4, 0);
+}
+
+UpCounter::UpCounter(uint32_t seed): RNGBase(4) {
+    state->set_state_bytes_from_int(seed, 4, 0);
+}
+
+void UpCounter::_seed_random(uint32_t new_seed) {
+    state->set_state_bytes_from_int(new_seed, 4, 0);
+}
+
+std::string UpCounter::name() {
+    return "UpCounter";
+}
+
+uint32_t UpCounter::_read_random(){
+    uint32_t s = state->get_state_bytes_as_int(0);
+    state->set_state_bytes_from_int(++s, 4, 0);
+    return s;
+}

--- a/rngs/software/UpCounter.hpp
+++ b/rngs/software/UpCounter.hpp
@@ -1,0 +1,17 @@
+#ifndef __UP_COUNTER_GENERATOR__
+#define __UP_COUNTER_GENERATOR__
+
+#include "RandomNumberGenerator.hpp"
+
+#include <stdint.h>
+#include <cstddef>
+
+class UpCounter: public RNGBase {
+    public:
+        UpCounter();
+        UpCounter(uint32_t seed);
+        uint32_t _read_random() override;
+        void _seed_random(uint32_t new_seed) override;
+        std::string name() override;
+};
+#endif // __UP_COUNTER_GENERATOR__


### PR DESCRIPTION
An UpCounter is not realistic pseudo-random number generation scheme. However, it is a viable implementation to quantify performance penalties of randomness. An UpCounter provides an uniformly iid distributed stream of numbers, but still retains locality advantages inherent in Von Neumann architectures. This PR addresses the feature request in #44. 